### PR TITLE
hotfix(ZEMA-3192):Fixes account number format returned by lydians

### DIFF
--- a/lib/m2y_lydians.rb
+++ b/lib/m2y_lydians.rb
@@ -3,6 +3,7 @@
 require 'm2y_lydians/configuration/configuration'
 require 'm2y_lydians/constants/constants'
 require 'm2y_lydians/modules/base'
+require 'm2y_lydians/modules/base_pix'
 
 require 'm2y_lydians/modules/account'
 require 'm2y_lydians/modules/authenticator'
@@ -11,6 +12,7 @@ require 'm2y_lydians/modules/billet'
 require 'm2y_lydians/modules/sms'
 require 'm2y_lydians/modules/statement'
 require 'm2y_lydians/modules/transaction'
+require 'm2y_lydians/modules/pix_key'
 
 module M2yLydians
   def self.configuration

--- a/lib/m2y_lydians/modules/base.rb
+++ b/lib/m2y_lydians/modules/base.rb
@@ -54,13 +54,9 @@ module M2yLydians
     end
 
     def self.format_response(original_response)
-      if original_response.to_s.include?('NroConta')
-        account_num = original_response.to_s.gsub(/\r?\n/, "").split(',')
-        account_num = account_num.select{ |line| line.include?('NroConta') }.first.split(':').last.strip
-      end
       original_response.body.force_encoding('UTF-8')
       response = original_response.parsed_response
-
+      binding.pry
       status_code = original_response.code
       if status_code.blank?
         # Erro 503 retorna um html em parsed_response
@@ -75,7 +71,6 @@ module M2yLydians
 
       begin
         response[:original_request] = original_response.request.raw_body
-        response[:account_number] = account_num if account_num.present?
         response[:url] = original_response.request.uri
       rescue StandardError
         response[:original_request] = nil

--- a/lib/m2y_lydians/modules/base.rb
+++ b/lib/m2y_lydians/modules/base.rb
@@ -56,7 +56,6 @@ module M2yLydians
     def self.format_response(original_response)
       original_response.body.force_encoding('UTF-8')
       response = original_response.parsed_response
-      binding.pry
       status_code = original_response.code
       if status_code.blank?
         # Erro 503 retorna um html em parsed_response

--- a/lib/m2y_lydians/modules/base.rb
+++ b/lib/m2y_lydians/modules/base.rb
@@ -54,6 +54,10 @@ module M2yLydians
     end
 
     def self.format_response(original_response)
+      if original_response.to_s.include?('NroConta')
+        account_num = original_response.to_s.gsub(/\r?\n/, "").split(',')
+        account_num = account_num.select{ |line| line.include?('NroConta') }.first.split(':').last.strip
+      end
       original_response.body.force_encoding('UTF-8')
       response = original_response.parsed_response
 
@@ -71,6 +75,7 @@ module M2yLydians
 
       begin
         response[:original_request] = original_response.request.raw_body
+        response[:account_number] = account_num if account_num.present?
         response[:url] = original_response.request.uri
       rescue StandardError
         response[:original_request] = nil

--- a/lib/m2y_lydians/modules/base_pix.rb
+++ b/lib/m2y_lydians/modules/base_pix.rb
@@ -1,12 +1,10 @@
 module M2yLydians
   class BasePix < Base
     def self.format_response(original_response)
-      binding.pry
       if original_response.to_s.include?('NroConta')
         account_num = original_response.to_s.gsub(/\r?\n/, "").split(',')
         account_num = account_num.select{ |line| line.include?('NroConta') }.first.split(':').last.strip
       end
-      binding.pry 
       original_response.body.force_encoding('UTF-8')
       response = original_response.parsed_response
 

--- a/lib/m2y_lydians/modules/base_pix.rb
+++ b/lib/m2y_lydians/modules/base_pix.rb
@@ -1,0 +1,38 @@
+module M2yLydians
+  class BasePix < Base
+    def self.format_response(original_response)
+      binding.pry
+      if original_response.to_s.include?('NroConta')
+        account_num = original_response.to_s.gsub(/\r?\n/, "").split(',')
+        account_num = account_num.select{ |line| line.include?('NroConta') }.first.split(':').last.strip
+      end
+      binding.pry 
+      original_response.body.force_encoding('UTF-8')
+      response = original_response.parsed_response
+
+      status_code = original_response.code
+      if status_code.blank?
+        # Erro 503 retorna um html em parsed_response
+        status_code = response.include?('Error 503') ? 503 : 500
+        description = 'Houve um erro inesperado, tente novamente mais tarde'
+      end
+
+      response = { body: response } if response.is_a?(Array)
+      response = {} unless response.is_a?(Hash)
+      response[:status_code] = status_code
+      response['Descricao'] = description if description.present?
+
+      begin
+        response[:original_request] = original_response.request.raw_body
+        response[:account_number] = account_num if account_num.present?
+        response[:url] = original_response.request.uri
+      rescue StandardError
+        response[:original_request] = nil
+        response[:url] = nil
+      end
+
+      # puts response
+      response
+    end
+  end
+end

--- a/lib/m2y_lydians/modules/pix_key.rb
+++ b/lib/m2y_lydians/modules/pix_key.rb
@@ -1,8 +1,8 @@
 module M2yLydians
-    class PixKey < BasePix
-        # Pix.svc/PIXConsultar
-        def self.search_pix_key(body)
-            post(pix_url + BASE_PIX_PATH + SEARCH_KEY_PATH, parsed_body(body), pix_headers)
-        end
+  class PixKey < BasePix
+    # Pix.svc/PIXConsultar
+    def self.search_pix_key(body)
+      post(pix_url + BASE_PIX_PATH + SEARCH_KEY_PATH, parsed_body(body), pix_headers)
     end
+  end
 end

--- a/lib/m2y_lydians/modules/pix_key.rb
+++ b/lib/m2y_lydians/modules/pix_key.rb
@@ -1,0 +1,8 @@
+module M2yLydians
+    class PixKey < BasePix
+        # Pix.svc/PIXConsultar
+        def self.search_pix_key(body)
+            post(pix_url + BASE_PIX_PATH + SEARCH_KEY_PATH, parsed_body(body), pix_headers)
+        end
+    end
+end

--- a/lib/m2y_lydians/version.rb
+++ b/lib/m2y_lydians/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module M2yLydians
-  VERSION = '1.13.0'
+  VERSION = '1.13.1'
 end


### PR DESCRIPTION
- Lydians manda um big float como response para numero de conta, o que acaba gerando um grande problema para contas com numero muito longo. Eles informaram que não podem mudar o datatype, logo, para amenizar a situação estou fazendo a extração do número ainda na response antes de fazer a conversão desta para objeto, isto para o número da conta.