### PR TITLE
hotfix(ZEMA-3734): Adds Httparty request timeout

### DIFF
--- a/lib/m2y_lydians/modules/base.rb
+++ b/lib/m2y_lydians/modules/base.rb
@@ -27,9 +27,9 @@ module M2yLydians
       # puts "Sending POST request to URL: #{url}"
       begin
         if M2yLydians.configuration.production?
-          response = HTTParty.post(url, headers: headers, body: body.to_json)
+          response = HTTParty.post(url, headers: headers, body: body.to_json, timeout: 30)
         else
-          response = HTTParty.post(url, headers: headers, body: body.to_json, debug_output: $stdout)
+          response = HTTParty.post(url, headers: headers, body: body.to_json, debug_output: $stdout, timeout: 30)
         end
       rescue Timeout::Error
         return timeout_response

--- a/lib/m2y_lydians/version.rb
+++ b/lib/m2y_lydians/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module M2yLydians
-  VERSION = '1.14.0'
+  VERSION = '1.14.2'
 end


### PR DESCRIPTION
Adiciona um timeout de 30s para httparty request devido a erro de timeout ocorrendo com frequência na lydians